### PR TITLE
feat(cf): terraform and cloudformation templates for cloudflow connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# DoiT CloudFlow Infrastructure
+
+This repository contains Infrastructure-as-Code (IaC) templates and modules for setting up secure cloud connections with the DoiT CloudFlow. 
+
+## Overview
+
+The repository provides automated infrastructure deployment scripts for establishing secure, cross-account connections between customer cloud environments and DoiT CloudFlow. These connections enable CloudFlow to collect metadata, provide insights, and manage cloud resources while maintaining security best practices through proper IAM roles and service accounts.
+
+## Supported Cloud Providers
+
+### Amazon Web Services (AWS)
+
+- **CloudFormation Templates**: Declarative YAML templates for quick deployment
+- **Terraform Modules**: Modular, reusable infrastructure code
+- **IAM Role Creation**: Cross-account roles with external ID security
+- **Flexible Permissions**: Support for both managed policies and custom actions
+
+### Google Cloud Platform (GCP)
+
+- **Terraform Modules**: Complete service account and IAM role management
+- **Multi-Level Binding**: Organization, folder, or project-level permissions
+- **Custom Role Creation**: Granular permission management
+- **Token Creator Binding**: Secure service account impersonation
+
+## Support and Documentation
+
+Each cloud provider directory contains detailed README files with:
+
+- Step-by-step deployment instructions
+- Parameter descriptions and examples
+- Troubleshooting guides
+- Security considerations
+- Best practices

--- a/connections/aws/cloudformation/README.md
+++ b/connections/aws/cloudformation/README.md
@@ -1,0 +1,94 @@
+## What This Stack Does
+
+1. Creates an IAM role with:
+   - Trust policy allowing the specified trusted account to assume the role
+   - External ID condition for additional security
+   - Base policy allowing the role to get its own policy information
+3. Conditionally attaches custom managed policies if ManagedPolicyArns is provided
+4. Conditionally creates a custom inline policy with specific actions if AllowedActions is provided
+5. Returns the ARN of the created role
+
+## Parameters
+
+- **RoleName**: The name of the IAM role to create (required)
+- **TrustedAccountId**: AWS Account ID that is allowed to assume this role (default: 068664126052)
+- **ExternalId**: External ID required for cross-account role assumption (required, provides additional security)
+- **ManagedPolicyArns**: Comma-separated list of AWS managed policy ARNs to attach to the role (optional)
+- **AllowedActions**: Comma-separated list of specific AWS actions to allow for the role (optional)
+
+## Security Features
+
+- **External ID**: Required when assuming the role, preventing confused deputy problems
+- **Trusted Account**: Only the specified account can assume this role
+- **Conditional Permissions**: CloudTrail access is only granted when explicitly requested
+- **Flexible Policy Attachment**: Supports custom managed policies for specific use cases
+- **Custom Actions**: Allows fine-grained control over specific AWS actions when needed
+
+## Custom Actions Policy
+
+When the `AllowedActions` parameter is provided with a comma-separated list of AWS actions, the stack creates a custom inline policy that grants the specified permissions. This allows for fine-grained control over the role's permissions without requiring managed policies.
+
+Example actions that can be specified:
+- `s3:GetObject,s3:ListBucket` - Read access to S3 buckets
+- `ec2:DescribeInstances,ec2:DescribeVolumes` - EC2 read permissions
+- `cloudwatch:GetMetricData,cloudwatch:ListMetrics` - CloudWatch monitoring permissions 
+
+## CI/CD
+
+Since we do not have a CI/CD pipeline for this CloudFormation template, manual deployment is required. After making any changes to the template file, please follow these steps:
+
+1. **Upload the updated template**: Upload `create_cloudflow_connection_role.yml` (or a new version) to the AWS S3 bucket `doit-cmp-ops-pub` in the `cloudflow` folder
+2. **Update the deployment link**: Ensure that links to the file in the code and documentation points to the correct version
+
+# CloudFormation Stack Deployment Link
+
+**Important: This stack must be deployed in the us-east-1 region only.**
+
+## Quick Deploy Link
+
+Use this link to deploy the CloudFormation stack that creates the IAM role for CloudFlow connection:
+
+```
+https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?templateUrl=https://doit-cmp-ops-pub.s3.us-east-1.amazonaws.com/cloudflow/create_cloudflow_connection_role.yml&stackName=DoitCloudFlowConnectionRole&param_RoleName=DoitCloudFlowConnectionRole&param_TrustedAccountId=068664126052&param_ExternalId=SomeProvidedExternalId&param_ManagedPolicyArns=arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess&param_AllowedActions=s3:GetObject,s3:ListBucket
+```
+
+## CLI Deployment Command
+
+Use this AWS CLI command to deploy the stack:
+
+```bash
+aws cloudformation create-stack \
+  --stack-name DoitCloudFlowConnectionRole \
+  --template-url https://github.com/doitintl/cloudflow-infra/connections/aws/cloudformation/create_cloudflow_connection_role.yml \
+  --parameters \
+    ParameterKey=RoleName,ParameterValue=DoitCloudFlowConnectionRole \
+    ParameterKey=TrustedAccountId,ParameterValue=068664126052 \
+    ParameterKey=ExternalId,ParameterValue=SomeProvidedExternalId \
+    ParameterKey=ManagedPolicyArns,ParameterValue="arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess" \
+    ParameterKey=AllowedActions,ParameterValue="'s3:GetObject,s3:ListBucket'" \    
+  --capabilities CAPABILITY_NAMED_IAM \
+  --region us-east-1
+```
+
+### Check Stack Status
+
+After running the create command, check the stack status:
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name DoitCloudFlowConnectionRole \
+  --region us-east-1 \
+  --query 'Stacks[0].StackStatus'
+```
+
+### Get Stack Outputs
+
+To get the role ARN after successful deployment:
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name DoitCloudFlowConnectionRole \
+  --region us-east-1 \
+  --query 'Stacks[0].Outputs[?OutputKey==`RoleArn`].OutputValue' \
+  --output text
+```

--- a/connections/aws/cloudformation/create_cloudflow_connection_role.yml
+++ b/connections/aws/cloudformation/create_cloudflow_connection_role.yml
@@ -1,0 +1,130 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Creates or updates a DoiT CloudFlow connection IAM role, must be used in us-east-1 region
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Role Configuration"
+        Parameters:
+          - RoleName
+          - TrustedAccountId
+          - ExternalId
+      - Label:
+          default: "Permissions"
+        Parameters:
+          - ManagedPolicyArns
+          - AllowedActions
+
+Parameters:
+  RoleName:
+    Type: String
+    Description: Name of the role to create or update
+    AllowedPattern: "^[a-zA-Z0-9+=,.@_-]+$"
+    ConstraintDescription: "Role name must contain only alphanumeric characters and the following: +=,.@_-"
+
+  TrustedAccountId:
+    Type: String
+    Description: AWS Account ID that is allowed to assume this role
+    AllowedPattern: '^\d{12}$'
+    ConstraintDescription: Account ID must be exactly 12 digits
+    Default: "068664126052"
+
+  ExternalId:
+    Type: String
+    Description: External ID required for cross-account role assumption (provides additional security)
+    MinLength: 1
+    MaxLength: 1224
+    AllowedPattern: "^[a-zA-Z0-9+=,.@_-]+$"
+    ConstraintDescription: "External ID must contain only alphanumeric characters and the following: +=,.@_-"
+
+  ManagedPolicyArns:
+    Type: CommaDelimitedList
+    Description: "Comma-separated list of AWS managed policy ARNs to attach to the role"
+    Default: ""
+
+  AllowedActions:
+    Type: CommaDelimitedList
+    Description: "Comma-separated list of actions to allow for the role"
+    Default: ""
+
+Conditions:
+  IsUSEast1: !Equals
+    - !Ref "AWS::Region"
+    - "us-east-1"
+  NotUSEast1: !Not [!Condition IsUSEast1]
+  HasManagedPolicies: !Not [!Equals [!Join ["", !Ref ManagedPolicyArns], ""]]
+  HasAllowedActions: !Not [!Equals [!Join ["", !Ref AllowedActions], ""]]
+
+Resources:
+  # Region check to prevent deployment outside us-east-1
+  RegionCheck:
+    Condition: NotUSEast1
+    Type: "AWS::CloudFormation::CustomResource"
+    Properties:
+      ServiceToken: "arn:aws:lambda:us-east-1:123456789012:function:nonexistent-function"
+
+  # Create the IAM role
+  DoitCloudFlowConnectionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref RoleName
+      Description: "Role for DoiT CloudFlow connection"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${TrustedAccountId}:root
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref ExternalId
+            Sid: "AllowAssumeRole"
+      Path: "/"
+      ManagedPolicyArns: !If [HasManagedPolicies, !Ref ManagedPolicyArns, []]
+
+  # Create the base inline policy for the role
+  DoitCloudFlowConnectionBasePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: DoitCloudFlowConnectionBasePolicy
+      Roles:
+        - !Ref DoitCloudFlowConnectionRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - "iam:ListAttachedRolePolicies"
+              - "iam:ListRolePolicies"
+              - "iam:GetRolePolicy"
+            Effect: Allow
+            Resource: !GetAtt DoitCloudFlowConnectionRole.Arn
+            Sid: "AllowListRolePolicies"
+          - Action:
+              - "iam:GetPolicy"
+              - "iam:GetPolicyVersion"
+            Effect: Allow
+            Resource: "*"
+            Sid: "AllowGetPolicy"
+
+  # Create the custom inline policy for the role
+  CloudFlowConnectionRoleCustomPolicy:
+    Type: AWS::IAM::Policy
+    Condition: HasAllowedActions
+    Properties:
+      PolicyName: CloudFlowConnectionRoleCustomPolicy
+      Roles:
+        - !Ref DoitCloudFlowConnectionRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action: !Ref AllowedActions
+            Effect: Allow
+            Resource: "*"
+            Sid: "AllowActions"
+
+Outputs:
+  RoleArn:
+    Value: !GetAtt DoitCloudFlowConnectionRole.Arn
+    Description: ARN of the created IAM role

--- a/connections/aws/terraform/README.md
+++ b/connections/aws/terraform/README.md
@@ -1,0 +1,152 @@
+# AWS CloudFlow Connection Role Terraform Module
+
+This Terraform module creates an IAM role for DoiT CloudFlow connections with configurable permissions and security controls.
+
+## Overview
+
+The module creates an IAM role that can be assumed by a trusted AWS account (default: DoiT's account) for CloudFlow integration purposes. It includes:
+
+- Cross-account role assumption with external ID validation
+- Configurable managed policy attachments
+- Custom inline policy support for specific actions
+- Base policy for CloudFlow connection requirements
+- Region restriction to us-east-1 for compliance
+
+## Features
+
+- **Security**: Uses external ID for additional cross-account security
+- **Flexibility**: Supports both managed policies and custom action lists
+- **Compliance**: Enforces us-east-1 region deployment
+- **Validation**: Input validation for role names, account IDs, and external IDs
+
+## Requirements
+
+- Terraform >= 1.0
+- AWS Provider ~> 5.0
+- AWS account with IAM permissions
+- Deployment must be in us-east-1 region
+
+## Usage
+
+### Basic Usage
+
+```hcl
+module "cloudflow_connection_role" {
+  source = "./create_cloudflow_connection_role.tf"
+
+  role_name     = "my-cloudflow-role"
+  external_id   = "unique-external-id-123"
+  
+  # Attach managed policies
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/ReadOnlyAccess",
+    "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  ]
+  
+  # Define custom actions
+  allowed_actions = [
+    "ec2:DescribeInstances",
+    "ec2:DescribeVolumes",    
+    "s3:ListBuckets"
+  ]
+}
+```
+
+## Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `role_name` | Name of the IAM role to create | `string` | - | Yes |
+| `external_id` | External ID for cross-account security | `string` | - | Yes |
+| `trusted_account_id` | AWS Account ID allowed to assume the role | `string` | `"068664126052"` | No |
+| `managed_policy_arns` | List of AWS managed policy ARNs to attach | `list(string)` | `[]` | No |
+| `allowed_actions` | List of custom actions to allow | `list(string)` | `[]` | No |
+
+### Variable Validation
+
+- **role_name**: Must contain only alphanumeric characters and: `+=,.@_-`
+- **external_id**: Must be 1-1224 characters, alphanumeric and: `+=,.@_-`
+- **trusted_account_id**: Must be exactly 12 digits
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `role_arn` | ARN of the created IAM role |
+| `role_name` | Name of the created IAM role |
+| `role_id` | ID of the created IAM role |
+
+## Resources Created
+
+1. **IAM Role**: Main role with cross-account trust policy
+2. **Base Policy**: Inline policy for CloudFlow connection requirements
+3. **Custom Policy**: Optional inline policy for specified actions
+4. **Policy Attachments**: Links managed policies and base policy to the role
+
+## Security Features
+
+- **External ID**: Required for cross-account role assumption
+- **Trust Policy**: Restricts assumption to specified AWS account
+- **Least Privilege**: Only grants specified permissions
+- **Region Restriction**: Enforces us-east-1 deployment
+
+### Prerequisites
+
+1. Ensure you're in the us-east-1 region
+2. Have appropriate AWS credentials configured
+3. Terraform initialized in the module directory
+
+### Commands
+
+```bash
+# Initialize Terraform
+terraform init
+
+# Plan the deployment
+terraform plan
+
+# Apply the configuration
+terraform apply
+```
+
+## Example Output
+
+```bash
+$ terraform apply
+
+Terraform will perform the following actions:
+
+  # aws_iam_role.doit_cloudflow_connection_role will be created
+  + resource "aws_iam_role" "doit_cloudflow_connection_role" {
+      + arn                   = (known after apply)
+      + assume_role_policy    = jsonencode(...)
+      + create_date          = (known after apply)
+      + description          = "Role for DoiT CloudFlow connection"
+      + id                   = (known after apply)
+      + name                 = "my-cloudflow-role"
+      + path                 = "/"
+      + unique_id            = (known after apply)
+    }
+
+  # ... additional resources ...
+
+Plan: 4 to add, 0 to change, 0 to destroy.
+
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to confirm.
+
+  Enter a value: yes
+
+aws_iam_role.doit_cloudflow_connection_role: Creating...
+aws_iam_role.doit_cloudflow_connection_role: Creation complete after 2s [id=my-cloudflow-role]
+...
+
+Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+role_arn = "arn:aws:iam::123456789012:role/my-cloudflow-role"
+role_name = "my-cloudflow-role"
+role_id = "my-cloudflow-role"
+```

--- a/connections/aws/terraform/create_cloudflow_connection/main.tf
+++ b/connections/aws/terraform/create_cloudflow_connection/main.tf
@@ -1,0 +1,193 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Variables (equivalent to CloudFormation Parameters)
+variable "role_name" {
+  description = "Name of the role to create or update"
+  type        = string
+  nullable    = false
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9+=,.@_-]+$", var.role_name))
+    error_message = "Role name must contain only alphanumeric characters and the following: +=,.@_-"
+  }
+}
+
+variable "trusted_account_id" {
+  description = "AWS Account ID that is allowed to assume this role"
+  type        = string
+  default     = "068664126052"
+  validation {
+    condition     = can(regex("^\\d{12}$", var.trusted_account_id))
+    error_message = "Account ID must be exactly 12 digits"
+  }
+}
+
+variable "external_id" {
+  description = "External ID required for cross-account role assumption (provides additional security)"
+  type        = string
+  nullable    = false
+  validation {
+    condition     = length(var.external_id) >= 1 && length(var.external_id) <= 1224
+    error_message = "External ID must be between 1 and 1224 characters"
+  }
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9+=,.@_-]+$", var.external_id))
+    error_message = "External ID must contain only alphanumeric characters and the following: +=,.@_-"
+  }
+}
+
+variable "managed_policy_arns" {
+  description = "List of AWS managed policy ARNs to attach to the role"
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_actions" {
+  description = "List of actions to allow for the role"
+  type        = list(string)
+  default     = []
+}
+
+# Data sources
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# Locals for conditional logic
+locals {
+  is_us_east_1         = data.aws_region.current.name == "us-east-1"
+  has_managed_policies = length(var.managed_policy_arns) > 0
+  has_allowed_actions  = length(var.allowed_actions) > 0
+}
+
+# Precondition check for us-east-1 region
+resource "null_resource" "region_check" {
+  count = local.is_us_east_1 ? 0 : 1
+
+  lifecycle {
+    precondition {
+      condition     = local.is_us_east_1
+      error_message = "This module must be deployed in us-east-1 region"
+    }
+  }
+}
+
+# Create the IAM role
+resource "aws_iam_role" "doit_cloudflow_connection_role" {
+  name        = var.role_name
+  description = "Role for DoiT CloudFlow connection"
+  path        = "/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${var.trusted_account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "sts:ExternalId" = var.external_id
+          }
+        }
+        Sid = "AllowAssumeRole"
+      }
+    ]
+  })
+
+  depends_on = [null_resource.region_check]
+}
+
+# Attach managed policies if provided
+resource "aws_iam_role_policy_attachment" "managed_policies" {
+  for_each = toset(var.managed_policy_arns)
+
+  role       = aws_iam_role.doit_cloudflow_connection_role.name
+  policy_arn = each.value
+
+  depends_on = [aws_iam_role.doit_cloudflow_connection_role]
+}
+
+# Create the base inline policy for the role
+resource "aws_iam_role_policy" "doit_cloudflow_connection_base_policy" {
+  name = "DoitCloudFlowConnectionBasePolicy"
+  role = aws_iam_role.doit_cloudflow_connection_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "iam:ListAttachedRolePolicies",
+          "iam:ListRolePolicies",
+          "iam:GetRolePolicy"
+        ]
+        Effect   = "Allow"
+        Resource = aws_iam_role.doit_cloudflow_connection_role.arn
+        Sid      = "AllowListRolePolicies"
+      },
+      {
+        Action = [
+          "iam:GetPolicy",
+          "iam:GetPolicyVersion"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+        Sid      = "AllowGetPolicy"
+      }
+    ]
+  })
+
+  depends_on = [aws_iam_role.doit_cloudflow_connection_role]
+}
+
+# Create the custom inline policy for the role if allowed actions are provided
+resource "aws_iam_role_policy" "cloudflow_connection_role_custom_policy" {
+  count = local.has_allowed_actions ? 1 : 0
+
+  name = "CloudFlowConnectionRoleCustomPolicy"
+  role = aws_iam_role.doit_cloudflow_connection_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = var.allowed_actions
+        Effect   = "Allow"
+        Resource = "*"
+        Sid      = "AllowActions"
+      }
+    ]
+  })
+
+  depends_on = [aws_iam_role.doit_cloudflow_connection_role]
+}
+
+
+output "role_arn" {
+  description = "ARN of the created IAM role"
+  value       = aws_iam_role.doit_cloudflow_connection_role.arn
+}
+
+output "role_name" {
+  description = "Name of the created IAM role"
+  value       = aws_iam_role.doit_cloudflow_connection_role.name
+}
+
+output "role_id" {
+  description = "ID of the created IAM role"
+  value       = aws_iam_role.doit_cloudflow_connection_role.id
+}
+
+output "base_policy_name" {
+  description = "Name of the base inline policy"
+  value       = aws_iam_role_policy.doit_cloudflow_connection_base_policy.name
+}

--- a/connections/aws/terraform/example/main.tf
+++ b/connections/aws/terraform/example/main.tf
@@ -1,0 +1,18 @@
+module "cloudflow_connection_role" {
+  source = "../create_cloudflow_connection"
+
+  role_name   = "my-cloudflow-role"
+  external_id = "unique-external-id-123"
+
+  # Attach managed policies
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/ReadOnlyAccess",
+    "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  ]
+
+  # Define custom actions
+  allowed_actions = [
+    "ec2:DescribeInstances",
+    "s3:ListBuckets"
+  ]
+}

--- a/connections/gcp/terraform/README.md
+++ b/connections/gcp/terraform/README.md
@@ -1,0 +1,79 @@
+# GCP Infrastructure Manager Deployment Commands
+
+This folder contains Terraform configuration to create a service account with custom IAM role bindings and predefined role bindings, supporting deployment at organization, folder, or project levels. Choose the appropriate command based on your desired binding target type.
+
+## Required Parameters
+
+- `YOUR_GCP_REGION`: The GCP region where the deployment will be created
+- `YOUR_GCP_PROJECT_ID`: The GCP project ID where the service account will be created
+- `YOUR_ORGANIZATION_ID`: The numerical ID of your GCP organization (required for org/folder bindings)
+- `YOUR_FOLDER_ID`: The numerical ID of the folder (required for folder binding)
+
+## Optional Parameters
+
+- `sa_name`: Service account ID (default: "cloudflow-connection-sa")
+- `custom_role_id`: Custom role ID (default: "cloudflowConnectionRole")
+- `custom_role_permissions`: List of permissions for the custom role
+- `predefined_roles`: List of predefined GCP roles to bind to the service account (e.g., ["roles/viewer", "roles/editor"])
+- `trusted_token_creator_sa`: Service account that can create tokens (default: doit-connect@me-doit-intl-com.iam.gserviceaccount.com)
+
+## Notes
+
+- The service account is always created at the project level
+- Custom roles are created at the organization level for org/folder bindings, or project level for project bindings
+- The deployment will create a service account, custom IAM role, and bind both the custom role and predefined roles to the service account at the specified target level
+- Predefined roles are bound alongside the custom role, providing additional permissions to the service account
+- List parameters (custom_role_permissions and predefined_roles) are passed as comma-separated scalar values and split into lists of strings inside the Terraform script itself. This approach is used due to GCP Infrastructure Manager CLI limitations with the `--input-values` parameter, which primarily supports simple scalar values rather than complex data structures like lists or maps
+
+## Examples of Predefined Roles
+
+Common predefined roles you might want to include:
+
+- `roles/viewer`: Read-only access to resources
+- `roles/editor`: Read and write access to resources
+- `roles/owner`: Full access to resources
+- `roles/compute.viewer`: Read-only access to Compute Engine resources
+- `roles/storage.objectViewer`: Read-only access to Cloud Storage objects
+- `roles/bigquery.dataViewer`: Read-only access to BigQuery data
+- `roles/logging.viewer`: Read-only access to Cloud Logging
+
+## Deployment Commands by Binding Level
+
+### 1. Organization-level Binding
+
+Use this command to bind the custom role and predefined roles to the service account at the organization level:
+
+```bash
+gcloud infra-manager deployments apply cloudflow-connection-sa-org-deployment \
+    --location=GCP_REGION \
+    --service-account=projects/GCP_PROJECT_ID/serviceAccounts/DEPLOYMENT_SERVICE_ACCOUNT@developer.gserviceaccount.com \
+    --project=GCP_PROJECT_ID \
+    --terraform-source-gcs="gs://doit-public-bucket/cloudflow/create_cloudflow_connection_sa/" \
+    --input-values="^;^sa_name=cloudflow-connection-sa;project_id=GCP_PROJECT_ID;custom_role_id=cloudflowConnectionRole;organization_id=ORGANIZATION_ID;iam_binding_target_type=organization;trusted_token_creator_sa=doit-connect@me-doit-intl-com.iam.gserviceaccount.com;custom_role_permissions=compute.instances.get,compute.instances.list,compute.disks.get,compute.disks.list,storage.objects.get,storage.objects.list;predefined_roles=roles/bigquery.dataViewer,roles/logging.viewer"
+```
+
+### 2. Folder-level Binding
+
+Use this command to bind the custom role and predefined roles to the service account at the folder level:
+
+```bash
+gcloud infra-manager deployments apply cloudflow-connection-sa-folder-deployment \
+    --location=GCP_REGION \
+    --service-account=projects/GCP_PROJECT_ID/serviceAccounts/DEPLOYMENT_SERVICE_ACCOUNT@developer.gserviceaccount.com \
+    --project=GCP_PROJECT_ID \
+    --terraform-source-gcs="gs://doit-public-bucket/cloudflow/create_cloudflow_connection_sa/" \
+    --input-values="^;^sa_name=cloudflow-connection-sa;project_id=GCP_PROJECT_ID;custom_role_id=cloudflowConnectionRole;organization_id=ORGANIZATION_ID;folder_id=FOLDER_ID;iam_binding_target_type=folder;trusted_token_creator_sa=doit-connect@me-doit-intl-com.iam.gserviceaccount.com;custom_role_permissions=compute.instances.get,compute.instances.list,compute.disks.get,compute.disks.list,storage.objects.get,storage.objects.list;predefined_roles=roles/bigquery.dataViewer,roles/logging.viewer"
+```
+
+### 3. Project-level Binding
+
+Use this command to bind the custom role and predefined roles to the service account at the project level:
+
+```bash
+gcloud infra-manager deployments apply cloudflow-connection-sa-project-deployment \
+    --location=GCP_REGION \
+    --service-account=projects/GCP_PROJECT_ID/serviceAccounts/DEPLOYMENT_SERVICE_ACCOUNT@developer.gserviceaccount.com \
+    --project=GCP_PROJECT_ID \
+    --terraform-source-gcs="gs://doit-public-bucket/cloudflow/create_cloudflow_connection_sa/" \
+    --input-values="^;^sa_name=cloudflow-connection;project_id=GCP_PROJECT_ID;custom_role_id=cloudflowConnectionRole;iam_binding_target_type=project;trusted_token_creator_sa=doit-connect@me-doit-intl-com.iam.gserviceaccount.com;custom_role_permissions=compute.instances.get,compute.instances.list;predefined_roles=roles/bigquery.dataViewer,roles/logging.viewer"
+```

--- a/connections/gcp/terraform/create_cloudflow_connection_sa/main.tf
+++ b/connections/gcp/terraform/create_cloudflow_connection_sa/main.tf
@@ -1,0 +1,269 @@
+# This Terraform script creates a GCP service account, a custom IAM role,
+# and then binds that custom role to the service account at a specified level
+# (organization, folder, or project).
+
+# --- Variables ---
+# These variables allow to customize the service account and custom role.
+
+variable "sa_name" {
+  description = "The ID of the service account to create (e.g., my-app-sa). Must be unique within the project."
+  type        = string
+  nullable    = false
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{5,29}$", var.sa_name))
+    error_message = "Service account name must be 6-30 characters long, start with a lowercase letter, and contain only lowercase letters, numbers, and hyphens."
+  }
+}
+
+variable "project_id" {
+  description = "The ID of the GCP project where the service account will be created. Service accounts are always project-level resources."
+  type        = string
+  nullable    = false
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "Project ID must be 6-30 characters long, start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, and hyphens."
+  }
+}
+
+variable "custom_role_id" {
+  description = "The ID for the custom role (e.g., myCustomViewerRole). Must be unique at its creation level."
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.custom_role_permissions == "" || can(regex("^[a-zA-Z][a-zA-Z0-9_]{2,63}$", var.custom_role_id))
+    error_message = "Custom role ID must be 3-64 characters long, start with a letter, and contain only letters, numbers, and underscores."
+  }
+}
+
+variable "predefined_roles" {
+  description = "A list of predefined roles to include in the custom role (e.g., [\"roles/viewer\", \"roles/editor\"])."
+  type        = string
+  default     = ""
+}
+
+variable "custom_role_permissions" {
+  description = "A list of permissions to include in the custom role (e.g., [\"compute.instances.get\", \"storage.objects.list\"])."
+  type        = string
+  default     = ""
+}
+
+variable "organization_id" {
+  description = "The numerical ID of your GCP organization. Required if iam_binding_target_type is 'organization' or 'folder'."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.iam_binding_target_type != "project" && can(regex("^[0-9]{12,20}$", var.organization_id)) || var.iam_binding_target_type == "project"
+    error_message = "Organization ID must be a 12-20 digit numerical ID."
+  }
+}
+
+variable "iam_binding_target_type" {
+  description = "The type of resource to bind the role to ('organization', 'folder', or 'project')."
+  type        = string
+  nullable    = false
+  validation {
+    condition     = contains(["organization", "folder", "project"], var.iam_binding_target_type)
+    error_message = "The iam_binding_target_type must be 'organization', 'folder', or 'project'."
+  }
+}
+
+variable "folder_id" {
+  description = "The numerical ID of the folder to bind the role to. Required if iam_binding_target_type is 'folder'."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.iam_binding_target_type == "folder" && can(regex("^[0-9]{12,20}$", var.folder_id)) || var.iam_binding_target_type != "folder"
+    error_message = "Folder ID must be a 12-20 digit numerical ID."
+  }
+}
+
+variable "trusted_token_creator_sa" {
+  description = "The service account that will be granted the token creator role on the created service account (e.g., doit-connect@me-doit-intl-com.iam.gserviceaccount.com)."
+  type        = string
+  default     = "doit-connect@me-doit-intl-com.iam.gserviceaccount.com"
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", var.trusted_token_creator_sa))
+    error_message = "Trusted token creator service account must be a valid email address format."
+  }
+  validation {
+    condition     = can(regex(".*@.*\\.iam\\.gserviceaccount\\.com$", var.trusted_token_creator_sa))
+    error_message = "Trusted token creator service account must be a valid GCP service account email ending with .iam.gserviceaccount.com."
+  }
+}
+
+# --- Provider Configuration ---
+provider "google" {
+  project = var.project_id
+}
+
+# --- Locals ---
+# Generate human-readable titles from IDs and process variable inputs
+
+locals {
+  # Generate service account display name from sa_name
+  sa_display_name = replace(
+    replace(
+      title(replace(var.sa_name, "/[-_]/", " ")),
+      " ", " "
+    ),
+    "/\\s+/", " "
+  )
+
+  # Generate custom role title from custom_role_id
+  custom_role_title = replace(
+    replace(
+      title(replace(var.custom_role_id, "/[-_]/", " ")),
+      " ", " "
+    ),
+    "/\\s+/", " "
+  )
+
+  # Convert comma-separated string to a list and filter out empty strings
+  predefined_roles_list = toset(var.predefined_roles != "" ? [for role in split(",", var.predefined_roles) : role if role != ""] : [])
+
+  # Convert comma-separated string to a list and filter out empty strings
+  custom_role_permissions_list = toset(var.custom_role_permissions != "" ? [for permission in split(",", var.custom_role_permissions) : permission if permission != ""] : [])
+}
+
+# --- Resources ---
+
+# --- 1. Create the GCP Service Account ---
+# Service accounts are always created within a specific project.
+resource "google_service_account" "custom_sa" {
+  account_id   = var.sa_name
+  display_name = local.sa_display_name
+  description  = "Service account created by DoiT CloudFlow connection"
+  project      = var.project_id
+}
+
+# --- 2. Create the Custom Role ---
+# This section conditionally creates the custom role at either the organization
+# or project level based on the 'custom_role_creation_level' variable.
+
+# Custom role created at the Organization level
+resource "google_organization_iam_custom_role" "org_custom_role" {
+  # This resource is created if binding to organization or folder (roles must be created at org level for folder binding)
+  count       = (var.iam_binding_target_type == "organization" || var.iam_binding_target_type == "folder") && length(local.custom_role_permissions_list) > 0 ? 1 : 0
+  role_id     = var.custom_role_id
+  title       = local.custom_role_title
+  description = "Custom role defined by DoiT CloudFlow connection"
+  permissions = local.custom_role_permissions_list
+  org_id      = var.organization_id
+  stage       = "GA" # Recommended for production use
+}
+
+# Custom role created at the Project level
+resource "google_project_iam_custom_role" "project_custom_role" {
+  # This resource is created only if binding to project level
+  count       = var.iam_binding_target_type == "project" && length(local.custom_role_permissions_list) > 0 ? 1 : 0
+  role_id     = var.custom_role_id
+  title       = local.custom_role_title
+  description = "Custom role defined by DoiT CloudFlow connection"
+  permissions = local.custom_role_permissions_list
+  project     = var.project_id
+  stage       = "GA" # Recommended for production use
+}
+
+# --- 3. Bind the Custom Role to the Service Account ---
+# This section conditionally binds the custom role to the service account
+# at the specified target resource level (organization, folder, or project).
+
+# Binding at Organization level
+resource "google_organization_iam_member" "org_binding" {
+  # This binding is created if the target type is 'organization'.
+  count  = var.iam_binding_target_type == "organization" && length(local.custom_role_permissions_list) > 0 ? 1 : 0
+  org_id = var.organization_id
+  role   = google_organization_iam_custom_role.org_custom_role[0].name
+  member = "serviceAccount:${google_service_account.custom_sa.email}"
+}
+
+# Binding at Folder level
+resource "google_folder_iam_member" "folder_binding" {
+  # This binding is created if the target type is 'folder'.
+  count  = var.iam_binding_target_type == "folder" && length(local.custom_role_permissions_list) > 0 ? 1 : 0
+  folder = var.folder_id
+  role   = google_organization_iam_custom_role.org_custom_role[0].name
+  member = "serviceAccount:${google_service_account.custom_sa.email}"
+}
+
+# Binding at Project level
+resource "google_project_iam_member" "project_binding" {
+  # This binding is created if the target type is 'project'.
+  count   = var.iam_binding_target_type == "project" && length(local.custom_role_permissions_list) > 0 ? 1 : 0
+  project = var.project_id
+  role    = google_project_iam_custom_role.project_custom_role[0].name
+  member  = "serviceAccount:${google_service_account.custom_sa.email}"
+}
+
+# --- 4. Bind Predefined Roles to the Service Account ---
+# This section conditionally binds predefined roles to the service account
+# at the specified target resource level (organization, folder, or project).
+
+# Predefined role bindings at Organization level
+resource "google_organization_iam_member" "org_predefined_bindings" {
+  # This binding is created for each predefined role if the target type is 'organization'.
+  for_each = var.iam_binding_target_type == "organization" ? local.predefined_roles_list : []
+  org_id   = var.organization_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.custom_sa.email}"
+}
+
+# Predefined role bindings at Folder level
+resource "google_folder_iam_member" "folder_predefined_bindings" {
+  # This binding is created for each predefined role if the target type is 'folder'.
+  for_each = var.iam_binding_target_type == "folder" ? local.predefined_roles_list : []
+  folder   = var.folder_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.custom_sa.email}"
+}
+
+# Predefined role bindings at Project level
+resource "google_project_iam_member" "project_predefined_bindings" {
+  # This binding is created for each predefined role if the target type is 'project'.
+  for_each = var.iam_binding_target_type == "project" ? local.predefined_roles_list : []
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.custom_sa.email}"
+}
+
+# --- Service Account Token Creator Binding ---
+# This binding allows the created service account to create tokens for other service accounts
+resource "google_service_account_iam_member" "token_creator_binding" {
+  service_account_id = google_service_account.custom_sa.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${var.trusted_token_creator_sa}"
+}
+
+# --- Outputs ---
+# These outputs provide useful information about the created resources.
+
+output "service_account_email" {
+  description = "The email address of the created service account."
+  value       = google_service_account.custom_sa.email
+}
+
+output "custom_role_full_name" {
+  description = "The full resource name of the created custom role."
+  value = var.iam_binding_target_type == "project" ? (
+    length(local.custom_role_permissions_list) > 0 ? google_project_iam_custom_role.project_custom_role[0].name : null
+    ) : (
+    length(local.custom_role_permissions_list) > 0 ? google_organization_iam_custom_role.org_custom_role[0].name : null
+  )
+}
+
+output "custom_role_creation_level_used" {
+  description = "The level at which the custom role was created."
+  value       = var.iam_binding_target_type == "project" ? "project" : "organization"
+}
+
+output "iam_binding_target_resource_type" {
+  description = "The type of resource where the custom role was bound."
+  value       = var.iam_binding_target_type
+}
+
+output "iam_binding_target_resource_id" {
+  description = "The ID of the resource where the custom role was bound."
+  value = var.iam_binding_target_type == "organization" ? var.organization_id : (
+    var.iam_binding_target_type == "folder" ? var.folder_id : var.project_id
+  )
+}

--- a/connections/gcp/terraform/example/main.tf
+++ b/connections/gcp/terraform/example/main.tf
@@ -1,0 +1,16 @@
+module "cloudflow_connection_sa" {
+  source = "../create_cloudflow_connection_sa"
+
+  sa_name                  = "my-cloudflow-sa"
+  trusted_token_creator_sa = "doit-connect@doit-cloudflow-sa.iam.gserviceaccount.com"
+
+  project_id              = "my-project-id"
+  iam_binding_target_type = "organization"
+  organization_id         = "123456789012"
+
+  custom_role_id          = "my_custom_role_id"
+  custom_role_permissions = "iam.roles.create, iam.roles.get"
+
+  predefined_roles = "roles/viewer"
+
+}


### PR DESCRIPTION
This PR is about to move[ existing code](https://github.com/doiteng/omni/tree/dev/server/shared/cloudflow/internal/connection) of IAC configs for Cloudflow Connections from omni repo

For the context: https://doitintl.slack.com/archives/C08LV9ND31B/p1753340991881739
